### PR TITLE
feat: do not use past.builtins.basetring (patch for python 3.10)

### DIFF
--- a/cookiecutter/prompt.py
+++ b/cookiecutter/prompt.py
@@ -11,9 +11,7 @@ from collections import OrderedDict
 import json
 
 import click
-from past.builtins import basestring
-
-from future.utils import iteritems
+import six
 
 from jinja2.exceptions import UndefinedError
 
@@ -164,7 +162,7 @@ def render_variable(env, raw, cookiecutter_dict):
             render_variable(env, v, cookiecutter_dict)
             for v in raw
         ]
-    elif not isinstance(raw, basestring):
+    elif not isinstance(raw, six.string_types):
         raw = str(raw)
 
     template = env.from_string(raw)
@@ -199,7 +197,7 @@ def prompt_for_config(context, no_input=False):
     # First pass: Handle simple and raw variables, plus choices.
     # These must be done first because the dictionaries keys and
     # values might refer to them.
-    for key, raw in iteritems(context[u'cookiecutter']):
+    for key, raw in context[u'cookiecutter'].items():
         if key.startswith(u'_'):
             cookiecutter_dict[key] = raw
             continue
@@ -224,7 +222,7 @@ def prompt_for_config(context, no_input=False):
             raise UndefinedVariableInTemplate(msg, err, context)
 
     # Second pass; handle the dictionaries.
-    for key, raw in iteritems(context[u'cookiecutter']):
+    for key, raw in context[u'cookiecutter'].items():
 
         try:
             if isinstance(raw, dict):

--- a/cookiecutter/replay.py
+++ b/cookiecutter/replay.py
@@ -9,7 +9,8 @@ from __future__ import unicode_literals
 
 import json
 import os
-from past.builtins import basestring
+
+import six
 
 from .utils import make_sure_path_exists
 
@@ -23,7 +24,7 @@ def dump(replay_dir, template_name, context):
     if not make_sure_path_exists(replay_dir):
         raise IOError('Unable to create replay dir at {}'.format(replay_dir))
 
-    if not isinstance(template_name, basestring):
+    if not isinstance(template_name, six.string_types):
         raise TypeError('Template name is required to be of type str')
 
     if not isinstance(context, dict):
@@ -39,7 +40,7 @@ def dump(replay_dir, template_name, context):
 
 
 def load(replay_dir, template_name):
-    if not isinstance(template_name, basestring):
+    if not isinstance(template_name, six.string_types):
         raise TypeError('Template name is required to be of type str')
 
     replay_file = get_file_name(replay_dir, template_name)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ with io.open('README.md', 'r', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    'future>=0.15.2',
     'binaryornot>=0.2.0',
     'jinja2>=2.7,<3; python_version < "3.6"',
     'jinja2>=2.7; python_version >= "3.6"',
@@ -35,6 +34,7 @@ requirements = [
     'poyo>=0.1.0',
     'jinja2-time>=0.1.0',
     'requests>=2.18.0',
+    'six>=1.10',
 ]
 
 if sys.argv[-1] == 'readme':

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 import platform
 
 import pytest
-from past.builtins import basestring
+import six
 
 from cookiecutter import prompt, exceptions, environment
 
@@ -36,7 +36,7 @@ def test_convert_to_str(mocker, raw_var, rendered_var):
 
     # Make sure that non None non str variables are converted beforehand
     if raw_var is not None:
-        if not isinstance(raw_var, basestring):
+        if not isinstance(raw_var, six.string_types):
             raw_var = str(raw_var)
         from_string.assert_called_once_with(raw_var)
     else:


### PR DESCRIPTION
It's a cherry pick of https://github.com/cookiecutter/cookiecutter/commit/82df6caa4b12f0da3db6f9f78a6dcb73a7443af7